### PR TITLE
Add missing types

### DIFF
--- a/Chickensoft.Serialization.Godot.Tests/test/src/AabbConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/AabbConverterTest.cs
@@ -1,0 +1,58 @@
+namespace Chickensoft.Serialization.Godot.Tests;
+
+using System.Text.Json;
+using Chickensoft.GoDotTest;
+using global::Godot;
+using Shouldly;
+
+public class AabbConverterTest : TestClass
+{
+  public AabbConverterTest(Node testScene) : base(testScene) { }
+
+  [Test]
+  public void CanConvert()
+  {
+    var converter = new AabbConverter();
+    converter.CanConvert(typeof(Aabb)).ShouldBeTrue();
+  }
+
+  [Test]
+  public void Converts()
+  {
+    GodotSerialization.Setup();
+
+    var options = new JsonSerializerOptions()
+    {
+      WriteIndented = true,
+      TypeInfoResolver = new SerializableTypeResolver(),
+    };
+
+    var obj = new Aabb(
+      new Vector3(1, 2, 3),
+      new Vector3(4, 5, 6)
+    );
+    var json = JsonSerializer.Serialize(obj, options);
+
+    json.ShouldBe(
+      /*lang=json*/
+      """
+      {
+        "position": {
+          "x": 1,
+          "y": 2,
+          "z": 3
+        },
+        "size": {
+          "x": 4,
+          "y": 5,
+          "z": 6
+        }
+      }
+      """
+    );
+
+    var deserialized = JsonSerializer.Deserialize<Aabb>(json, options);
+
+    deserialized.ShouldBe(obj);
+  }
+}

--- a/Chickensoft.Serialization.Godot.Tests/test/src/AabbConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/AabbConverterTest.cs
@@ -49,7 +49,7 @@ public class AabbConverterTest : TestClass
         }
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Aabb>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/BasisConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/BasisConverterTest.cs
@@ -55,7 +55,7 @@ public class BasisConverterTest : TestClass
         }
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Basis>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/PlaneConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/PlaneConverterTest.cs
@@ -1,0 +1,54 @@
+namespace Chickensoft.Serialization.Godot.Tests;
+
+using System.Text.Json;
+using Chickensoft.GoDotTest;
+using global::Godot;
+using Shouldly;
+
+public class PlaneConverterTest : TestClass
+{
+  public PlaneConverterTest(Node testScene) : base(testScene) { }
+
+  [Test]
+  public void CanConvert()
+  {
+    var converter = new PlaneConverter();
+    converter.CanConvert(typeof(Plane)).ShouldBeTrue();
+  }
+
+  [Test]
+  public void Converts()
+  {
+    GodotSerialization.Setup();
+
+    var options = new JsonSerializerOptions()
+    {
+      WriteIndented = true,
+      TypeInfoResolver = new SerializableTypeResolver(),
+    };
+
+    var obj = new Plane(
+      new Vector3(1, 2, 3),
+      7
+    );
+    var json = JsonSerializer.Serialize(obj, options);
+
+    json.ShouldBe(
+      /*lang=json*/
+      """
+      {
+        "normal": {
+          "x": 1,
+          "y": 2,
+          "z": 3
+        },
+        "d": 7
+      }
+      """
+    );
+
+    var deserialized = JsonSerializer.Deserialize<Plane>(json, options);
+
+    deserialized.ShouldBe(obj);
+  }
+}

--- a/Chickensoft.Serialization.Godot.Tests/test/src/PlaneConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/PlaneConverterTest.cs
@@ -45,7 +45,7 @@ public class PlaneConverterTest : TestClass
         "d": 7
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Plane>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/ProjectionConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/ProjectionConverterTest.cs
@@ -65,7 +65,7 @@ public class ProjectionConverterTest : TestClass
         }
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Projection>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/ProjectionConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/ProjectionConverterTest.cs
@@ -1,0 +1,74 @@
+namespace Chickensoft.Serialization.Godot.Tests;
+
+using System.Text.Json;
+using Chickensoft.GoDotTest;
+using global::Godot;
+using Shouldly;
+
+public class ProjectionConverterTest : TestClass
+{
+  public ProjectionConverterTest(Node testScene) : base(testScene) { }
+
+  [Test]
+  public void CanConvert()
+  {
+    var converter = new ProjectionConverter();
+    converter.CanConvert(typeof(Projection)).ShouldBeTrue();
+  }
+
+  [Test]
+  public void Converts()
+  {
+    GodotSerialization.Setup();
+
+    var options = new JsonSerializerOptions()
+    {
+      WriteIndented = true,
+      TypeInfoResolver = new SerializableTypeResolver(),
+    };
+
+    var obj = new Projection(
+      new Vector4(1, 2, 3, 4),
+      new Vector4(5, 6, 7, 8),
+      new Vector4(9, 10, 11, 12),
+      new Vector4(13, 14, 15, 16)
+    );
+    var json = JsonSerializer.Serialize(obj, options);
+
+    json.ShouldBe(
+      /*lang=json*/
+      """
+      {
+        "x": {
+          "x": 1,
+          "y": 2,
+          "z": 3,
+          "w": 4
+        },
+        "y": {
+          "x": 5,
+          "y": 6,
+          "z": 7,
+          "w": 8
+        },
+        "z": {
+          "x": 9,
+          "y": 10,
+          "z": 11,
+          "w": 12
+        },
+        "w": {
+          "x": 13,
+          "y": 14,
+          "z": 15,
+          "w": 16
+        }
+      }
+      """
+    );
+
+    var deserialized = JsonSerializer.Deserialize<Projection>(json, options);
+
+    deserialized.ShouldBe(obj);
+  }
+}

--- a/Chickensoft.Serialization.Godot.Tests/test/src/QuaternionConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/QuaternionConverterTest.cs
@@ -40,7 +40,7 @@ public class QuaternionConverterTest : TestClass
         "w": 4
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Quaternion>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/QuaternionConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/QuaternionConverterTest.cs
@@ -1,0 +1,49 @@
+namespace Chickensoft.Serialization.Godot.Tests;
+
+using System.Text.Json;
+using Chickensoft.GoDotTest;
+using global::Godot;
+using Shouldly;
+
+public class QuaternionConverterTest : TestClass
+{
+  public QuaternionConverterTest(Node testScene) : base(testScene) { }
+
+  [Test]
+  public void CanConvert()
+  {
+    var converter = new QuaternionConverter();
+    converter.CanConvert(typeof(Quaternion)).ShouldBeTrue();
+  }
+
+  [Test]
+  public void Converts()
+  {
+    GodotSerialization.Setup();
+
+    var options = new JsonSerializerOptions()
+    {
+      WriteIndented = true,
+      TypeInfoResolver = new SerializableTypeResolver(),
+    };
+
+    var obj = new Quaternion(1, 2, 3, 4);
+    var json = JsonSerializer.Serialize(obj, options);
+
+    json.ShouldBe(
+      /*lang=json*/
+      """
+      {
+        "x": 1,
+        "y": 2,
+        "z": 3,
+        "w": 4
+      }
+      """
+    );
+
+    var deserialized = JsonSerializer.Deserialize<Quaternion>(json, options);
+
+    deserialized.ShouldBe(obj);
+  }
+}

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Rect2ConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Rect2ConverterTest.cs
@@ -48,7 +48,7 @@ public class Rect2ConverterTest : TestClass
         }
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Rect2>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Rect2IConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Rect2IConverterTest.cs
@@ -48,7 +48,7 @@ public class Rect2IConverterTest : TestClass
         }
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Rect2I>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Transform2DConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Transform2DConverterTest.cs
@@ -53,7 +53,7 @@ public class Transform2DConverterTest : TestClass
         }
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Transform2D>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Transform3DConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Transform3DConverterTest.cs
@@ -66,7 +66,7 @@ public class Transform3DConverterTest : TestClass
         }
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Transform3D>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Vector2ConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Vector2ConverterTest.cs
@@ -38,7 +38,7 @@ public class Vector2ConverterTest : TestClass
         "y": 2
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Vector2>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Vector2IConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Vector2IConverterTest.cs
@@ -38,7 +38,7 @@ public class Vector2IConverterTest : TestClass
         "y": 2
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Vector2I>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Vector3ConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Vector3ConverterTest.cs
@@ -39,7 +39,7 @@ public class Vector3ConverterTest : TestClass
         "z": 3
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Vector3>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Vector3IConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Vector3IConverterTest.cs
@@ -39,7 +39,7 @@ public class Vector3IConverterTest : TestClass
         "z": 3
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Vector3I>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Vector4ConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Vector4ConverterTest.cs
@@ -40,7 +40,7 @@ public class Vector4ConverterTest : TestClass
         "w": 4
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Vector4>(json, options);
 

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Vector4ConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Vector4ConverterTest.cs
@@ -1,0 +1,49 @@
+namespace Chickensoft.Serialization.Godot.Tests;
+
+using System.Text.Json;
+using Chickensoft.GoDotTest;
+using global::Godot;
+using Shouldly;
+
+public class Vector4ConverterTest : TestClass
+{
+  public Vector4ConverterTest(Node testScene) : base(testScene) { }
+
+  [Test]
+  public void CanConvert()
+  {
+    var converter = new Vector4Converter();
+    converter.CanConvert(typeof(Vector4)).ShouldBeTrue();
+  }
+
+  [Test]
+  public void Converts()
+  {
+    GodotSerialization.Setup();
+
+    var options = new JsonSerializerOptions()
+    {
+      WriteIndented = true,
+      TypeInfoResolver = new SerializableTypeResolver(),
+    };
+
+    var obj = new Vector4(1, 2, 3, 4);
+    var json = JsonSerializer.Serialize(obj, options);
+
+    json.ShouldBe(
+      /*lang=json*/
+      """
+      {
+        "x": 1,
+        "y": 2,
+        "z": 3,
+        "w": 4
+      }
+      """
+    );
+
+    var deserialized = JsonSerializer.Deserialize<Vector4>(json, options);
+
+    deserialized.ShouldBe(obj);
+  }
+}

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Vector4IConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Vector4IConverterTest.cs
@@ -1,0 +1,62 @@
+namespace Chickensoft.Serialization.Godot.Tests;
+
+using System.Text.Json;
+using Chickensoft.GoDotTest;
+using global::Godot;
+using Shouldly;
+
+public class Vector4IConverterTest : TestClass
+{
+  public Vector4IConverterTest(Node testScene) : base(testScene) { }
+
+  [Test]
+  public void CanConvert()
+  {
+    var converter = new Vector4IConverter();
+    converter.CanConvert(typeof(Vector4I)).ShouldBeTrue();
+  }
+
+  [Test]
+  public void Converts()
+  {
+    GodotSerialization.Setup();
+
+    var options = new JsonSerializerOptions()
+    {
+      WriteIndented = true,
+      TypeInfoResolver = new SerializableTypeResolver(),
+    };
+
+    var obj = new Vector4I(1, 2, 3, 4);
+    var json = JsonSerializer.Serialize(obj, options);
+
+    json.ShouldBe(
+      /*lang=json*/
+      """
+      {
+        "x": 1,
+        "y": 2,
+        "z": 3,
+        "w": 4
+      }
+      """
+    );
+
+    var deserialized = JsonSerializer.Deserialize<Vector4I>(json, options);
+
+    deserialized.ShouldBe(obj);
+  }
+
+  [Test]
+  public void ThrowsOnDecimals()
+  {
+    GodotSerialization.Setup();
+
+    const string json = """{"x": 1.1, "y": 2.2, "z": 3.3, "w": 4.4}""";
+    var options = new JsonSerializerOptions()
+    {
+      TypeInfoResolver = new SerializableTypeResolver(),
+    };
+    Should.Throw<JsonException>(() => JsonSerializer.Deserialize<Vector4I>(json, options));
+  }
+}

--- a/Chickensoft.Serialization.Godot.Tests/test/src/Vector4IConverterTest.cs
+++ b/Chickensoft.Serialization.Godot.Tests/test/src/Vector4IConverterTest.cs
@@ -40,7 +40,7 @@ public class Vector4IConverterTest : TestClass
         "w": 4
       }
       """
-    );
+      , StringCompareShould.IgnoreLineEndings);
 
     var deserialized = JsonSerializer.Deserialize<Vector4I>(json, options);
 

--- a/Chickensoft.Serialization.Godot/src/AabbConverter.cs
+++ b/Chickensoft.Serialization.Godot/src/AabbConverter.cs
@@ -1,0 +1,73 @@
+namespace Chickensoft.Serialization.Godot;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using global::Godot;
+
+/// <summary>Aabb JSON converter.</summary>
+public class AabbConverter : JsonConverter<Aabb>
+{
+  /// <inheritdoc />
+  public override bool CanConvert(Type typeToConvert) =>
+    typeToConvert == typeof(Aabb);
+
+  /// <inheritdoc />
+  public override Aabb Read(
+    ref Utf8JsonReader reader,
+    Type typeToConvert,
+    JsonSerializerOptions options
+  )
+  {
+    var position = new Vector3();
+    var size = new Vector3();
+
+    while (reader.Read())
+    {
+      if (reader.TokenType == JsonTokenType.EndObject)
+      {
+        return new Aabb(position, size);
+      }
+
+      if (reader.TokenType != JsonTokenType.PropertyName)
+      {
+        continue;
+      }
+
+      var propertyName = reader.GetString();
+      reader.Read();
+
+      switch (propertyName)
+      {
+        case "position":
+          position = JsonSerializer.Deserialize<Vector3>(ref reader, options);
+          break;
+        case "size":
+          size = JsonSerializer.Deserialize<Vector3>(ref reader, options);
+          break;
+        default:
+          break;
+      }
+    }
+
+    throw new JsonException("Unexpected end when reading Aabb.");
+  }
+
+  /// <inheritdoc />
+  public override void Write(
+    Utf8JsonWriter writer,
+    Aabb value,
+    JsonSerializerOptions options
+  )
+  {
+    var resolver = options.TypeInfoResolver;
+    var vectorTypeInfo = resolver!.GetTypeInfo(typeof(Vector3), options)!;
+
+    writer.WriteStartObject();
+    writer.WritePropertyName("position");
+    JsonSerializer.Serialize(writer, value.Position, vectorTypeInfo);
+    writer.WritePropertyName("size");
+    JsonSerializer.Serialize(writer, value.Size, vectorTypeInfo);
+    writer.WriteEndObject();
+  }
+}

--- a/Chickensoft.Serialization.Godot/src/GodotSerialization.cs
+++ b/Chickensoft.Serialization.Godot/src/GodotSerialization.cs
@@ -26,6 +26,7 @@ public static class GodotSerialization
     Serializer.AddConverter(new Vector4IConverter());
     Serializer.AddConverter(new QuaternionConverter());
     Serializer.AddConverter(new ColorConverter());
+    Serializer.AddConverter(new AabbConverter());
     Serializer.AddConverter(new PlaneConverter());
     Serializer.AddConverter(new ProjectionConverter());
   }

--- a/Chickensoft.Serialization.Godot/src/GodotSerialization.cs
+++ b/Chickensoft.Serialization.Godot/src/GodotSerialization.cs
@@ -26,5 +26,6 @@ public static class GodotSerialization
     Serializer.AddConverter(new Vector4IConverter());
     Serializer.AddConverter(new QuaternionConverter());
     Serializer.AddConverter(new ColorConverter());
+    Serializer.AddConverter(new ProjectionConverter());
   }
 }

--- a/Chickensoft.Serialization.Godot/src/GodotSerialization.cs
+++ b/Chickensoft.Serialization.Godot/src/GodotSerialization.cs
@@ -15,13 +15,15 @@ public static class GodotSerialization
   {
     Serializer.AddConverter(new Vector2Converter());
     Serializer.AddConverter(new Vector2IConverter());
+    Serializer.AddConverter(new Rect2Converter());
+    Serializer.AddConverter(new Rect2IConverter());
     Serializer.AddConverter(new Transform2DConverter());
     Serializer.AddConverter(new Vector3Converter());
     Serializer.AddConverter(new Vector3IConverter());
     Serializer.AddConverter(new BasisConverter());
     Serializer.AddConverter(new Transform3DConverter());
+    Serializer.AddConverter(new Vector4Converter());
+    Serializer.AddConverter(new Vector4IConverter());
     Serializer.AddConverter(new ColorConverter());
-    Serializer.AddConverter(new Rect2Converter());
-    Serializer.AddConverter(new Rect2IConverter());
   }
 }

--- a/Chickensoft.Serialization.Godot/src/GodotSerialization.cs
+++ b/Chickensoft.Serialization.Godot/src/GodotSerialization.cs
@@ -26,6 +26,7 @@ public static class GodotSerialization
     Serializer.AddConverter(new Vector4IConverter());
     Serializer.AddConverter(new QuaternionConverter());
     Serializer.AddConverter(new ColorConverter());
+    Serializer.AddConverter(new PlaneConverter());
     Serializer.AddConverter(new ProjectionConverter());
   }
 }

--- a/Chickensoft.Serialization.Godot/src/GodotSerialization.cs
+++ b/Chickensoft.Serialization.Godot/src/GodotSerialization.cs
@@ -24,6 +24,7 @@ public static class GodotSerialization
     Serializer.AddConverter(new Transform3DConverter());
     Serializer.AddConverter(new Vector4Converter());
     Serializer.AddConverter(new Vector4IConverter());
+    Serializer.AddConverter(new QuaternionConverter());
     Serializer.AddConverter(new ColorConverter());
   }
 }

--- a/Chickensoft.Serialization.Godot/src/PlaneConverter.cs
+++ b/Chickensoft.Serialization.Godot/src/PlaneConverter.cs
@@ -1,0 +1,72 @@
+namespace Chickensoft.Serialization.Godot;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using global::Godot;
+
+/// <summary>Plane JSON converter.</summary>
+public class PlaneConverter : JsonConverter<Plane>
+{
+  /// <inheritdoc />
+  public override bool CanConvert(Type typeToConvert) =>
+    typeToConvert == typeof(Plane);
+
+  /// <inheritdoc />
+  public override Plane Read(
+    ref Utf8JsonReader reader,
+    Type typeToConvert,
+    JsonSerializerOptions options
+  )
+  {
+    var normal = new Vector3();
+    var d = 0f;
+
+    while (reader.Read())
+    {
+      if (reader.TokenType == JsonTokenType.EndObject)
+      {
+        return new Plane(normal, d);
+      }
+
+      if (reader.TokenType != JsonTokenType.PropertyName)
+      {
+        continue;
+      }
+
+      var propertyName = reader.GetString();
+      reader.Read();
+
+      switch (propertyName)
+      {
+        case "normal":
+          normal = JsonSerializer.Deserialize<Vector3>(ref reader, options);
+          break;
+        case "d":
+          d = reader.GetSingle();
+          break;
+        default:
+          break;
+      }
+    }
+
+    throw new JsonException("Unexpected end when reading Plane.");
+  }
+
+  /// <inheritdoc />
+  public override void Write(
+    Utf8JsonWriter writer,
+    Plane value,
+    JsonSerializerOptions options
+  )
+  {
+    var resolver = options.TypeInfoResolver;
+    var vectorTypeInfo = resolver!.GetTypeInfo(typeof(Vector3), options)!;
+
+    writer.WriteStartObject();
+    writer.WritePropertyName("normal");
+    JsonSerializer.Serialize(writer, value.Normal, vectorTypeInfo);
+    writer.WriteNumber("d", value.D);
+    writer.WriteEndObject();
+  }
+}

--- a/Chickensoft.Serialization.Godot/src/ProjectionConverter.cs
+++ b/Chickensoft.Serialization.Godot/src/ProjectionConverter.cs
@@ -1,0 +1,85 @@
+namespace Chickensoft.Serialization.Godot;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using global::Godot;
+
+/// <summary>Projection JSON converter.</summary>
+public class ProjectionConverter : JsonConverter<Projection>
+{
+  /// <inheritdoc />
+  public override bool CanConvert(Type typeToConvert) =>
+    typeToConvert == typeof(Projection);
+
+  /// <inheritdoc />
+  public override Projection Read(
+    ref Utf8JsonReader reader,
+    Type typeToConvert,
+    JsonSerializerOptions options
+  )
+  {
+    var x = new Vector4();
+    var y = new Vector4();
+    var z = new Vector4();
+    var w = new Vector4();
+
+    while (reader.Read())
+    {
+      if (reader.TokenType == JsonTokenType.EndObject)
+      {
+        return new Projection(x, y, z, w);
+      }
+
+      if (reader.TokenType != JsonTokenType.PropertyName)
+      {
+        continue;
+      }
+
+      var propertyName = reader.GetString();
+      reader.Read();
+
+      switch (propertyName)
+      {
+        case "x":
+          x = JsonSerializer.Deserialize<Vector4>(ref reader, options);
+          break;
+        case "y":
+          y = JsonSerializer.Deserialize<Vector4>(ref reader, options);
+          break;
+        case "z":
+          z = JsonSerializer.Deserialize<Vector4>(ref reader, options);
+          break;
+        case "w":
+          w = JsonSerializer.Deserialize<Vector4>(ref reader, options);
+          break;
+        default:
+          break;
+      }
+    }
+
+    throw new JsonException("Unexpected end when reading Projection.");
+  }
+
+  /// <inheritdoc />
+  public override void Write(
+    Utf8JsonWriter writer,
+    Projection value,
+    JsonSerializerOptions options
+  )
+  {
+    var resolver = options.TypeInfoResolver;
+    var vectorTypeInfo = resolver!.GetTypeInfo(typeof(Vector4), options)!;
+
+    writer.WriteStartObject();
+    writer.WritePropertyName("x");
+    JsonSerializer.Serialize(writer, value.X, vectorTypeInfo);
+    writer.WritePropertyName("y");
+    JsonSerializer.Serialize(writer, value.Y, vectorTypeInfo);
+    writer.WritePropertyName("z");
+    JsonSerializer.Serialize(writer, value.Z, vectorTypeInfo);
+    writer.WritePropertyName("w");
+    JsonSerializer.Serialize(writer, value.W, vectorTypeInfo);
+    writer.WriteEndObject();
+  }
+}

--- a/Chickensoft.Serialization.Godot/src/QuaternionConverter.cs
+++ b/Chickensoft.Serialization.Godot/src/QuaternionConverter.cs
@@ -1,0 +1,78 @@
+namespace Chickensoft.Serialization.Godot;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using global::Godot;
+
+/// <summary>Quaternion JSON converter.</summary>
+public class QuaternionConverter : JsonConverter<Quaternion>
+{
+  /// <inheritdoc />
+  public override bool CanConvert(Type typeToConvert) =>
+    typeToConvert == typeof(Quaternion);
+
+  /// <inheritdoc />
+  public override Quaternion Read(
+    ref Utf8JsonReader reader,
+    Type typeToConvert,
+    JsonSerializerOptions options
+  )
+  {
+    var x = 0f;
+    var y = 0f;
+    var z = 0f;
+    var w = 0f;
+
+    while (reader.Read())
+    {
+      if (reader.TokenType == JsonTokenType.EndObject)
+      {
+        return new Quaternion(x, y, z, w);
+      }
+
+      if (reader.TokenType != JsonTokenType.PropertyName)
+      {
+        continue;
+      }
+
+      var propertyName = reader.GetString();
+      reader.Read();
+
+      switch (propertyName)
+      {
+        case "x":
+          x = reader.GetSingle();
+          break;
+        case "y":
+          y = reader.GetSingle();
+          break;
+        case "z":
+          z = reader.GetSingle();
+          break;
+        case "w":
+          w = reader.GetSingle();
+          break;
+        default:
+          break;
+      }
+    }
+
+    throw new JsonException("Unexpected end when reading Quaternion.");
+  }
+
+  /// <inheritdoc />
+  public override void Write(
+    Utf8JsonWriter writer,
+    Quaternion value,
+    JsonSerializerOptions options
+  )
+  {
+    writer.WriteStartObject();
+    writer.WriteNumber("x", value.X);
+    writer.WriteNumber("y", value.Y);
+    writer.WriteNumber("z", value.Z);
+    writer.WriteNumber("w", value.W);
+    writer.WriteEndObject();
+  }
+}

--- a/Chickensoft.Serialization.Godot/src/Vector4Converter.cs
+++ b/Chickensoft.Serialization.Godot/src/Vector4Converter.cs
@@ -1,0 +1,78 @@
+namespace Chickensoft.Serialization.Godot;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using global::Godot;
+
+/// <summary>Vector4 JSON converter.</summary>
+public class Vector4Converter : JsonConverter<Vector4>
+{
+  /// <inheritdoc />
+  public override bool CanConvert(Type typeToConvert) =>
+    typeToConvert == typeof(Vector4);
+
+  /// <inheritdoc />
+  public override Vector4 Read(
+    ref Utf8JsonReader reader,
+    Type typeToConvert,
+    JsonSerializerOptions options
+  )
+  {
+    var x = 0f;
+    var y = 0f;
+    var z = 0f;
+    var w = 0f;
+
+    while (reader.Read())
+    {
+      if (reader.TokenType == JsonTokenType.EndObject)
+      {
+        return new Vector4(x, y, z, w);
+      }
+
+      if (reader.TokenType != JsonTokenType.PropertyName)
+      {
+        continue;
+      }
+
+      var propertyName = reader.GetString();
+      reader.Read();
+
+      switch (propertyName)
+      {
+        case "x":
+          x = reader.GetSingle();
+          break;
+        case "y":
+          y = reader.GetSingle();
+          break;
+        case "z":
+          z = reader.GetSingle();
+          break;
+        case "w":
+          w = reader.GetSingle();
+          break;
+        default:
+          break;
+      }
+    }
+
+    throw new JsonException("Unexpected end when reading Vector4.");
+  }
+
+  /// <inheritdoc />
+  public override void Write(
+    Utf8JsonWriter writer,
+    Vector4 value,
+    JsonSerializerOptions options
+  )
+  {
+    writer.WriteStartObject();
+    writer.WriteNumber("x", value.X);
+    writer.WriteNumber("y", value.Y);
+    writer.WriteNumber("z", value.Z);
+    writer.WriteNumber("w", value.W);
+    writer.WriteEndObject();
+  }
+}

--- a/Chickensoft.Serialization.Godot/src/Vector4IConverter.cs
+++ b/Chickensoft.Serialization.Godot/src/Vector4IConverter.cs
@@ -1,0 +1,78 @@
+namespace Chickensoft.Serialization.Godot;
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using global::Godot;
+
+/// <summary>Vector4I JSON converter.</summary>
+public class Vector4IConverter : JsonConverter<Vector4I>
+{
+  /// <inheritdoc />
+  public override bool CanConvert(Type typeToConvert) =>
+    typeToConvert == typeof(Vector4I);
+
+  /// <inheritdoc />
+  public override Vector4I Read(
+    ref Utf8JsonReader reader,
+    Type typeToConvert,
+    JsonSerializerOptions options
+  )
+  {
+    var x = 0;
+    var y = 0;
+    var z = 0;
+    var w = 0;
+
+    while (reader.Read())
+    {
+      if (reader.TokenType == JsonTokenType.EndObject)
+      {
+        return new Vector4I(x, y, z, w);
+      }
+
+      if (reader.TokenType != JsonTokenType.PropertyName)
+      {
+        continue;
+      }
+
+      var propertyName = reader.GetString();
+      reader.Read();
+
+      switch (propertyName)
+      {
+        case "x":
+          x = reader.GetInt32();
+          break;
+        case "y":
+          y = reader.GetInt32();
+          break;
+        case "z":
+          z = reader.GetInt32();
+          break;
+        case "w":
+          w = reader.GetInt32();
+          break;
+        default:
+          break;
+      }
+    }
+
+    throw new JsonException("Unexpected end when reading Vector4I.");
+  }
+
+  /// <inheritdoc />
+  public override void Write(
+    Utf8JsonWriter writer,
+    Vector4I value,
+    JsonSerializerOptions options
+  )
+  {
+    writer.WriteStartObject();
+    writer.WriteNumber("x", value.X);
+    writer.WriteNumber("y", value.Y);
+    writer.WriteNumber("z", value.Z);
+    writer.WriteNumber("w", value.W);
+    writer.WriteEndObject();
+  }
+}

--- a/README.md
+++ b/README.md
@@ -7,12 +7,16 @@ Godot-specific JSON converters for [Chickensoft.Serialization].
 Please contribute! This only supports the following types:
 
 - ✅ `Vector2`
-- ✅ `Vector2i`
+- ✅ `Vector2I`
+- ✅ `Rect2`
+- ✅ `Rect2I`
 - ✅ `Transform2D`
 - ✅ `Vector3`
-- ✅ `Vector3i`
+- ✅ `Vector3I`
 - ✅ `Basis`
 - ✅ `Transform3D`
+- ✅ `Vector4`
+- ✅ `Vector4I`
 - ✅ `Color`
 
 Be sure to place the following line somewhere before you start serializing/deserializing:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Please contribute! This only supports the following types:
 - ✅ `Transform3D`
 - ✅ `Vector4`
 - ✅ `Vector4I`
+- ✅ `Quaternion`
 - ✅ `Color`
 
 Be sure to place the following line somewhere before you start serializing/deserializing:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Please contribute! This only supports the following types:
 - ✅ `Vector4I`
 - ✅ `Quaternion`
 - ✅ `Color`
+- ✅ `Aabb (AABB)`
 - ✅ `Plane`
 - ✅ `Projection`
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Please contribute! This only supports the following types:
 - ✅ `Vector4I`
 - ✅ `Quaternion`
 - ✅ `Color`
+- ✅ `Plane`
 - ✅ `Projection`
 
 Be sure to place the following line somewhere before you start serializing/deserializing:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Please contribute! This only supports the following types:
 - ✅ `Vector4I`
 - ✅ `Quaternion`
 - ✅ `Color`
+- ✅ `Projection`
 
 Be sure to place the following line somewhere before you start serializing/deserializing:
 

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
   ],
   "words": [
     "assemblyfilters",
+    "aabb",
     "devbuild",
     "skipautoprops",
     "automerge",


### PR DESCRIPTION
Adds the following Variant types:
- `Vector4`
- `Vector4I`
- `Quaternion`
- `AABB`
- `Plane`
- `Projection`

Please note that these are not **all** of the missing types. Currently, these remain:
- `Object` (GodotObject): objects should not be serialized entirely due to security concerns with scripts and resources, instead something like [SaveFileBuilder](https://github.com/chickensoft-games/SaveFileBuilder) should be used.
- `StringName` and `NodePath` : these have implicit conversion to string, so I felt that it was unnecessary to add, especially since it would just look like `"&<string>"` or `"^<string>"` when serialized.
- `Callable` and `Signal`: these are currently impossible to serialize in Godot, as they require references to objects to function properly, which cannot be obtained while deserializing in JSON.

I also took the liberty of fixing tests in this PR, since it was just a one line change per test, but please let me know if I should separate this to another PR.